### PR TITLE
Revert "Update alpine Docker tag to v3.9"

### DIFF
--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -6,7 +6,7 @@ FROM hashicorp/terraform:light AS terraform
 FROM hashicorp/packer:light AS packer
 FROM prom/prometheus:v2.7.0 AS prometheus
 
-FROM alpine:3.9 AS packages
+FROM alpine:3.8 AS packages
 
 RUN apk add --no-cache \
     zip \

--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -6,7 +6,7 @@ FROM hashicorp/terraform:light AS terraform
 FROM hashicorp/packer:light AS packer
 FROM prom/prometheus:v2.7.0 AS prometheus
 
-FROM alpine:3.9 AS packages
+FROM alpine:3.8 AS packages
 
 RUN apk add --no-cache \
     zip \

--- a/py-build/Dockerfile
+++ b/py-build/Dockerfile
@@ -6,7 +6,7 @@ FROM hashicorp/terraform:light AS terraform
 FROM hashicorp/packer:light AS packer
 FROM prom/prometheus:v2.7.0 AS prometheus
 
-FROM alpine:3.9 AS packages
+FROM alpine:3.8 AS packages
 
 RUN apk add --no-cache \
     zip \

--- a/socat/Dockerfile
+++ b/socat/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.8
 
 RUN apk add --no-cache \
   ca-certificates \

--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -6,7 +6,7 @@ FROM hashicorp/terraform:light AS terraform
 FROM hashicorp/packer:light AS packer
 FROM prom/prometheus:v2.7.0 AS prometheus
 
-FROM alpine:3.9 AS build
+FROM alpine:3.8 AS build
 
 RUN apk add --no-cache \
     make \


### PR DESCRIPTION
Reverts qlik-oss/dockerfiles#13

Looks like there are some weird incompatibilities right now, errors like:

```
Error relocating /usr/bin/ssh: explicit_bzero: symbol not found
```

Reverting for now!