### PR TITLE
Adding cc-test-reporter to all build images, and golangci-lint

### DIFF
--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -9,6 +9,12 @@ FROM prom/alertmanager:v0.18.0 AS alertmanager
 FROM mikefarah/yq:2.4.0 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.15.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.14.2 AS helm
+FROM golangci/golangci-lint:v1.17 AS golangci-lint
+
+FROM alpine:3.10 AS cc-test-reporter
+
+RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+RUN chmod +x /bin/cc-test-reporter
 
 FROM alpine:3.10 AS packages
 
@@ -65,6 +71,8 @@ COPY --from=yq /usr/bin/yq /usr/bin/yq
 COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm 
+COPY --from=cc-test-reporter /bin/cc-test-reporter /bin/cc-test-reporter
+COPY --from=golangci-lint /usr/bin/golangci-lint /bin/
 
 COPY --from=packages / /
 COPY --from=gopackages /go /go

--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -10,6 +10,11 @@ FROM mikefarah/yq:2.4.0 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.15.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.14.2 AS helm
 
+FROM alpine:3.10 AS cc-test-reporter
+
+RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+RUN chmod +x /bin/cc-test-reporter
+
 FROM alpine:3.10 AS packages
 
 RUN apk add --no-cache \
@@ -63,7 +68,8 @@ COPY --from=alertmanager /bin/amtool /bin/amtool
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm 
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=cc-test-reporter /bin/cc-test-reporter /bin/cc-test-reporter
 
 COPY --from=packages / /
 COPY --from=nodepackages / /

--- a/py-build/Dockerfile
+++ b/py-build/Dockerfile
@@ -10,6 +10,11 @@ FROM mikefarah/yq:2.4.0 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.15.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.14.2 AS helm
 
+FROM alpine:3.10 AS cc-test-reporter
+
+RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+RUN chmod +x /bin/cc-test-reporter
+
 FROM alpine:3.10 AS packages
 
 RUN apk add --no-cache \
@@ -64,7 +69,8 @@ COPY --from=alertmanager /bin/amtool /bin/amtool
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm 
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=cc-test-reporter /bin/cc-test-reporter /bin/cc-test-reporter
 
 COPY --from=packages / /
 COPY --from=pypackages / /

--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -10,6 +10,11 @@ FROM mikefarah/yq:2.4.0 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.15.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.14.2 AS helm
 
+FROM alpine:3.10 AS cc-test-reporter
+
+RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+RUN chmod +x /bin/cc-test-reporter
+
 FROM alpine:3.10 AS packages
 
 RUN apk add --no-cache \
@@ -34,8 +39,8 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libz.so.1 /usr/glibc-compat/lib \
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
- 
- RUN mkdir hub && \
+
+RUN mkdir hub && \
     wget https://github.com/github/hub/releases/download/v2.12.2/hub-linux-amd64-2.12.2.tgz -O- | \
     tar xz --strip-components 1 --directory hub \
     && ./hub/install \
@@ -53,6 +58,7 @@ COPY --from=alertmanager /bin/amtool /bin/amtool
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm 
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=cc-test-reporter /bin/cc-test-reporter /bin/cc-test-reporter
 
 COPY --from=packages / /


### PR DESCRIPTION
- [x] Adding `golangci-lint` to `go-build` image
- [x] Adding `cc-test-reporter` to all `-build` images

Signed-off-by: Dave Henderson <David.Henderson@qlik.com>