### PR TITLE
install build-base for go-build image

### DIFF
--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -33,7 +33,8 @@ RUN apk add --no-cache \
     py2-pip \
     openssh-client \
     openssl \
-    libgcc
+    libgcc \
+    build-base
 
 ENV GLIBC=2.28-r0
 


### PR DESCRIPTION
Required for some linters, and for `go test -race`

Signed-off-by: Dave Henderson <David.Henderson@qlik.com>