### PR TITLE
fix: back to alpine:3.8

### DIFF
--- a/py-build/Dockerfile
+++ b/py-build/Dockerfile
@@ -10,12 +10,12 @@ FROM mikefarah/yq:2.4.0 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.15.3 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.14.3 AS helm
 
-FROM alpine:3.10 AS cc-test-reporter
+FROM alpine:3.8 AS cc-test-reporter
 
 RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
 RUN chmod +x /bin/cc-test-reporter
 
-FROM alpine:3.10 AS packages
+FROM alpine:3.8 AS packages
 
 RUN apk add --no-cache \
     zip \


### PR DESCRIPTION
Seeing this when trying to git clone:

Error relocating /usr/bin/ssh: explicit_bzero: symbol not found

... right when the first successful build of py-build arrives, after the
version bump to from alpine:3.8 to alpine:3.10. So I conjecture that's the
cause ... and downgrading does seem to fix it.