### PR TITLE
Configure renovate to use pep440 for the python image versioning scheme

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "pip_requirements": {
     "fileMatch": [".*-requirements.txt"]
-  }
+  },
+  "packageRules": [
+    {
+      "datasources": ["docker"],
+      "packageNames": ["python"],
+      "versionScheme": "pep440"
+    }
+  ]
 }


### PR DESCRIPTION
Attempting to fix issue I've run into in #154 and #159 (https://github.com/renovatebot/renovate/issues/4827). Based on docs in https://docs.renovatebot.com/docker/#version-compatibility

Signed-off-by: Dave Henderson <dhenderson@gmail.com>