### PR TITLE
[tiny build] Adds google cloud sdk

### DIFF
--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -9,6 +9,7 @@ FROM prom/alertmanager:v0.20.0 AS alertmanager
 FROM mikefarah/yq:2.4.2 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.17.4 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.16.3 AS helm
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:285.0.1-alpine AS google-cloud-sdk
 
 FROM alpine:3.11.3 AS cc-test-reporter
 
@@ -60,5 +61,8 @@ COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=cc-test-reporter /bin/cc-test-reporter /bin/cc-test-reporter
+COPY --from=google-cloud-sdk /google-cloud-sdk/bin/ /usr/local/bin/
+COPY --from=google-cloud-sdk /google-cloud-sdk/lib/ /usr/local/lib/
+COPY --from=google-cloud-sdk /google-cloud-sdk/platform/ /usr/local/platform/
 
 COPY --from=packages / /


### PR DESCRIPTION
This PR adds the `google-cloud-sdk` dependencies to the tiny build image.

References used:

https://github.com/GoogleCloudPlatform/cloud-sdk-docker#alpine-based-images
https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/alpine/Dockerfile
https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/GLOBAL/cloud-sdk?gcrImageListsize=30