### PR TITLE
Downgrade golangci-lint to avoid bugs in go-build

### DIFF
--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -10,7 +10,7 @@ FROM mikefarah/yq:2.4.2 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.18.0 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.16.5 AS helm
 FROM lachlanevenson/k8s-helm:v3.1.2 AS helm3
-FROM golangci/golangci-lint:v1.24 AS golangci-lint
+FROM golangci/golangci-lint:v1.23.8-alpine AS golangci-lint
 
 FROM alpine:3.11.5 AS cc-test-reporter
 


### PR DESCRIPTION
Signed-off-by: Dave Henderson <dhenderson@gmail.com>