### PR TITLE
Bump node-build to node v12

### DIFF
--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -50,14 +50,14 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
 
-FROM node:10.20.1-alpine AS nodepackages
+FROM node:12.16.2-alpine AS nodepackages
 
 RUN npm config set unsafe-perm true
 RUN npm install -g \
   mocha \
   serverless
 
-FROM node:10.20.1-alpine AS build
+FROM node:12.16.2-alpine AS build
 
 COPY --from=gomplate /gomplate /bin/gomplate
 COPY --from=docker /usr/local/bin/docker /bin/docker


### PR DESCRIPTION
Bumping node-build to node 12 since node 10 is going into maintenance and node 12 is LTS :+1: