### PR TITLE
bugfix: revert to Docker 19.03.8

### DIFF
--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM hairyhenderson/gomplate:v3.7.0-slim AS gomplate
-FROM docker:19.03.9 AS docker
+FROM docker:19.03.8 AS docker
 FROM docker/compose:1.25.5 AS compose
 FROM vault:0.11.6 AS vault
 FROM hashicorp/terraform:0.12.25 AS terraform

--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM hairyhenderson/gomplate:v3.7.0-slim AS gomplate
-FROM docker:19.03.9 AS docker
+FROM docker:19.03.8 AS docker
 FROM docker/compose:1.25.5 AS compose
 FROM vault:0.11.6 AS vault
 FROM hashicorp/terraform:0.12.25 AS terraform

--- a/py-build/Dockerfile
+++ b/py-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM hairyhenderson/gomplate:v3.7.0-slim AS gomplate
-FROM docker:19.03.9 AS docker
+FROM docker:19.03.8 AS docker
 FROM docker/compose:1.25.5 AS compose
 FROM vault:0.11.6 AS vault
 FROM hashicorp/terraform:0.12.25 AS terraform

--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -1,5 +1,5 @@
 FROM hairyhenderson/gomplate:v3.7.0-slim AS gomplate
-FROM docker:19.03.9 AS docker
+FROM docker:19.03.8 AS docker
 FROM docker/compose:1.25.5 AS compose
 FROM vault:1.4.2 AS vault
 FROM hashicorp/terraform:0.12.25 AS terraform


### PR DESCRIPTION
There's a regression in the Docker 19.03.9 CLI (https://github.com/docker/cli/issues/2533) that causes commands to fail against older engines (such as used in CircleCI):

```
Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```

It's fixed upstream and will be released with 19.03.10, but until then we need to revert!

Signed-off-by: Dave Henderson <David.Henderson@qlik.com>