### PR TITLE
[tiny-build] Adding cortextool to tiny-build

### DIFF
--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -6,6 +6,7 @@ FROM hashicorp/terraform:0.13.4 AS terraform
 FROM hashicorp/packer:1.6.4 AS packer
 FROM prom/prometheus:v2.21.0 AS prometheus
 FROM prom/alertmanager:v0.21.0 AS alertmanager
+FROM grafana/cortex-tools:v0.4.0 AS cortextool
 FROM mikefarah/yq:2.4.2 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.19.2 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.16.11 AS helm
@@ -60,6 +61,7 @@ COPY --from=terraform /bin/terraform /bin/terraform
 COPY --from=packer /bin/packer /bin/packer
 COPY --from=prometheus /bin/promtool /bin/promtool
 COPY --from=alertmanager /bin/amtool /bin/amtool
+COPY --from=cortextool /usr/bin/cortextool /bin/cortextool
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
In order to call the Cortex Alertmanagers and Ruler API's during deployment.

https://github.com/grafana/cortex-tools#cortextool
https://github.com/grafana/cortex-tools/releases/tag/v0.4.0