### PR TITLE
Add mysql client to tiny-build

### DIFF
--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -30,7 +30,8 @@ RUN apk add --no-cache \
     py3-pip \
     bash \
     jq \
-    curl
+    curl \
+    mysql-client
 
 ENV GLIBC=2.31-r0
 


### PR DESCRIPTION
Adding MySQL client to enable the deployment of Grafana Annotations DB Infra.

Currently it's in a failed state due to missing`mysql` CLI. 

Part of the terraform codes sets a random password using the CLI during deploy. 
https://github.com/qlik-trial/helm-environment-overrides/blob/e495425010bdd546d0720b49299b5971f8a1a8df/infrastructure/shared-services/grafana_annotation_db/db/mysql.tf#L54