### PR TITLE
[helm] Bump all images to 3.6.2

### DIFF
--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -9,7 +9,7 @@ FROM prom/alertmanager:v0.23.0 AS alertmanager
 FROM mikefarah/yq:4.18.1 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.21.9 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.17.0 AS helm2
-FROM lachlanevenson/k8s-helm:v3.6.1 AS helm
+FROM lachlanevenson/k8s-helm:v3.6.2 AS helm
 FROM golangci/golangci-lint:v1.44.0-alpine AS golangci-lint
 
 FROM alpine:3.15 AS cc-test-reporter

--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -9,7 +9,7 @@ FROM prom/alertmanager:v0.21.0 AS alertmanager
 FROM mikefarah/yq:4.9.6 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.20.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.17.0 AS helm2
-FROM lachlanevenson/k8s-helm:v3.6.1 AS helm
+FROM lachlanevenson/k8s-helm:v3.6.2 AS helm
 
 FROM alpine:3.12.3 AS cc-test-reporter
 

--- a/py-build/Dockerfile
+++ b/py-build/Dockerfile
@@ -9,7 +9,7 @@ FROM prom/alertmanager:v0.21.0 AS alertmanager
 FROM mikefarah/yq:4.9.6 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.20.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.17.0 AS helm2
-FROM lachlanevenson/k8s-helm:v3.6.1 AS helm
+FROM lachlanevenson/k8s-helm:v3.6.2 AS helm
 
 FROM alpine:3.12.3 AS cc-test-reporter
 

--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -10,7 +10,7 @@ FROM grafana/cortex-tools:v0.7.0 AS cortextool
 FROM mikefarah/yq:4.9.6 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.20.1 AS kubectl
 FROM lachlanevenson/k8s-helm:v2.17.0 AS helm2
-FROM lachlanevenson/k8s-helm:v3.5.3 AS helm
+FROM lachlanevenson/k8s-helm:v3.6.2 AS helm
 FROM r.j3ss.co/img:v0.5.11 AS img
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-alpine AS google-cloud-sdk
 FROM instrumenta/conftest:v0.21.0 AS conftest


### PR DESCRIPTION
Ref.: https://hub.docker.com/layers/lachlanevenson/k8s-helm/v3.6.2/images/sha256-e87f97c2d292be41764f2d23511c8271e97eebf6b3d73917703d941e5335279f?context=explore