### PR TITLE
[node-build] Use LTS version of nodejs

### DIFF
--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -50,7 +50,7 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
 
-FROM node:16.17.0-alpine AS nodepackages 
+FROM node:16.17.0-alpine AS nodepackages
 
 RUN npm config set unsafe-perm true
 RUN npm install -g \

--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -50,7 +50,7 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
 
-FROM node:16.17.0-alpine AS nodepackages
+FROM node:16.17.0-alpine AS nodepackages 
 
 RUN npm config set unsafe-perm true
 RUN npm install -g \

--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -50,14 +50,14 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
 
-FROM node:17.3.0-alpine AS nodepackages
+FROM node:16.17.0-alpine AS nodepackages
 
 RUN npm config set unsafe-perm true
 RUN npm install -g \
   mocha \
   serverless
 
-FROM node:17.3.0-alpine AS build
+FROM node:16.17.0-alpine AS build
 
 COPY --from=gomplate /gomplate /bin/gomplate
 COPY --from=docker /usr/local/bin/docker /bin/docker


### PR DESCRIPTION
An lot of packages do not support non-LTS versions of Node and will often fail package installations. Generally practice is to stick with LTS versions. That being said, we likely need to prevent renovate to update it as well. 

There are a few weeks until v18 becomes LTS but this should do until then:

From https://nodejs.org/en/about/releases/
<img width="796" alt="image" src="https://user-images.githubusercontent.com/5672257/187477100-5f68d33b-25b0-4696-85f2-1b3964917952.png">
