### PR TITLE
chore(node-build): update to node 18

### DIFF
--- a/node-build/Dockerfile
+++ b/node-build/Dockerfile
@@ -50,14 +50,14 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
 
-FROM node:16.17.0-alpine AS nodepackages
+FROM node:18.12.1-alpine AS nodepackages
 
 RUN npm config set unsafe-perm true
 RUN npm install -g \
   mocha \
   serverless
 
-FROM node:16.17.0-alpine AS build
+FROM node:18.12.1-alpine AS build
 
 COPY --from=gomplate /gomplate /bin/gomplate
 COPY --from=docker /usr/local/bin/docker /bin/docker


### PR DESCRIPTION
Follow up of https://github.com/qlik-oss/dockerfiles/pull/358

The Latest LTS version available https://nodejs.org/en/