### PR TITLE
Adding a softlink to make use of Helm3

### DIFF
--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -54,6 +54,8 @@ RUN mkdir hub && \
     && ./hub/install \
     && rm -r hub
 
+RUN ln -s /usr/local/bin/helm /usr/local/bin/helm3
+
 FROM alpine:3.12.3 AS build
 
 COPY --from=gomplate /gomplate /bin/gomplate


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/qlik-trial/elastic-charts/394385/workflows/d1e91a16-2690-4447-9e5c-f291b48abf3b/jobs/1212665
missing helm3 in the new version