### PR TITLE
Update prometheus and cortex-tools versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,41 +37,6 @@ jobs:
         docker push qlik/go-build
         docker push qlik/go-build:$(date +'%Y-%m-%d')
       if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
-  docker-build-gradle:
-    name: docker build gradle
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: "1"
-    steps:
-    - name: docker version
-      run: docker version
-    - uses: actions/checkout@master
-    - name: build
-      run: docker build --progress plain --iidfile gradle/image.iid -f gradle/Dockerfile gradle/
-    - name: tag
-      run: |
-        docker tag $(< gradle/image.iid) ghcr.io/qlik-oss/gradle
-        docker tag $(< gradle/image.iid) ghcr.io/qlik-oss/gradle:$(date +'%Y-%m-%d')
-        docker tag $(< gradle/image.iid) qlik/gradle
-        docker tag $(< gradle/image.iid) qlik/gradle:$(date +'%Y-%m-%d')
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
-      if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
-    - name: login to DockerHub
-      run: |
-        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-      if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
-    - name: docker push
-      run: |
-        docker push ghcr.io/qlik-oss/gradle
-        docker push ghcr.io/qlik-oss/gradle:$(date +'%Y-%m-%d')
-        docker push qlik/gradle
-        docker push qlik/gradle:$(date +'%Y-%m-%d')
-      if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
   docker-build-node-build:
     name: docker build node-build
     runs-on: ubuntu-latest

--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -5,8 +5,8 @@ FROM vault:1.6.1 AS vault
 FROM hashicorp/terraform:1.0.0 AS terraform
 FROM hashicorp/packer:1.6.6 AS packer
 FROM prom/prometheus:v2.41.0 AS prometheus
-FROM prom/alertmanager:v0.21.0 AS alertmanager
-FROM grafana/cortex-tools:v0.7.0 AS cortextool
+FROM prom/alertmanager:v0.24.0 AS alertmanager
+FROM grafana/cortex-tools:v0.10.7 AS cortextool
 FROM mikefarah/yq:4.31.2 AS yq
 FROM lachlanevenson/k8s-kubectl:v1.22.16 AS kubectl
 FROM lachlanevenson/k8s-helm:v3.10.2 AS helm2


### PR DESCRIPTION
Update the versions of the following components:

- Prometheus
- cortex-tool

The Gradle docker image is not being used anymore. As the first step, this PR will disable the Gradle GH action.