### PR TITLE
Go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         docker push qlik/go-build
         docker push qlik/go-build:$(date +'%Y-%m-%d')
       if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
-  docker-build-go-build-1.18:
+  docker-build-go-build-1-18:
     name: docker build go-build-1.18
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
         docker push qlik/go-build
         docker push qlik/go-build:$(date +'%Y-%m-%d')
       if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
-  docker-build-go-build-1.18: name: docker build go-build-1.18
+  docker-build-go-build-1.18:
+    name: docker build go-build-1.18
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,40 @@ jobs:
         docker push qlik/go-build
         docker push qlik/go-build:$(date +'%Y-%m-%d')
       if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
+  docker-build-go-build-1.18: name: docker build go-build-1.18
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
+    steps:
+    - name: docker version
+      run: docker version
+    - uses: actions/checkout@master
+    - name: build
+      run: docker build --progress plain --iidfile go-build-1.18/image.iid -f go-build-1.18/Dockerfile go-build-1.18/
+    - name: tag
+      run: |
+        docker tag $(< go-build-1.18/image.iid) ghcr.io/qlik-oss/go-build:1.18
+        docker tag $(< go-build-1.18/image.iid) ghcr.io/qlik-oss/go-build:1.18-$(date +'%Y-%m-%d')
+        docker tag $(< go-build-1.18/image.iid) qlik/go-build:1.18
+        docker tag $(< go-build-1.18/image.iid) qlik/go-build:1.18-$(date +'%Y-%m-%d')
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_TOKEN }}
+      if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
+    - name: login to DockerHub
+      run: |
+        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
+    - name: docker push
+      run: |
+        docker push ghcr.io/qlik-oss/go-build:1.18
+        docker push ghcr.io/qlik-oss/go-build:1.18-$(date +'%Y-%m-%d')
+        docker push qlik/go-build:1.18
+        docker push qlik/go-build:1.18-$(date +'%Y-%m-%d')
+      if: github.ref == 'refs/heads/master' && github.repository == 'qlik-oss/dockerfiles'
   docker-build-node-build:
     name: docker build node-build
     runs-on: ubuntu-latest

--- a/go-build-1.18/Dockerfile
+++ b/go-build-1.18/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache \
     libgcc \
     build-base
 
-ENV GLIBC=2.31-r0
+ENV GLIBC=2.35-r1
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 

--- a/go-build-1.18/Dockerfile
+++ b/go-build-1.18/Dockerfile
@@ -1,0 +1,72 @@
+FROM hairyhenderson/gomplate:v3.10.0-slim AS gomplate
+FROM docker:23.0.1 AS docker
+FROM docker/compose:1.29.2 AS compose
+FROM vault:1.9.3 AS vault
+FROM hashicorp/terraform:1.1.5 AS terraform
+FROM hashicorp/packer:1.7.10 AS packer
+FROM prom/prometheus:v2.33.1 AS prometheus
+FROM prom/alertmanager:v0.23.0 AS alertmanager
+FROM mikefarah/yq:4.18.1 AS yq
+FROM lachlanevenson/k8s-kubectl:v1.21.9 AS kubectl
+FROM lachlanevenson/k8s-helm:v3.10.2 AS helm2
+FROM lachlanevenson/k8s-helm:v3.8.0 AS helm
+FROM golangci/golangci-lint:v1.44.0-alpine AS golangci-lint
+
+FROM alpine:3.18 AS cc-test-reporter
+
+RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+RUN chmod +x /bin/cc-test-reporter
+
+FROM alpine:3.18 AS packages
+
+RUN apk add --no-cache \
+    zip \
+    unzip \
+    bats \
+    bash \
+    grep \
+    sed \
+    make \
+    jq \
+    curl \
+    git \
+    python3 \
+    py3-pip \
+    openssh-client \
+    openssl \
+    libgcc \
+    build-base
+
+ENV GLIBC=2.31-r0
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+
+COPY awscli-requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+RUN rm -rf requirements.txt ~/.cache
+
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/glibc-$GLIBC.apk \
+  && apk add --no-cache glibc-$GLIBC.apk \
+  && rm glibc-$GLIBC.apk \
+  && ln -s /lib/libz.so.1 /usr/glibc-compat/lib \
+  && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
+  && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
+
+FROM golang:1.18.1-alpine AS build
+
+COPY --from=gomplate /gomplate /bin/gomplate
+COPY --from=docker /usr/local/bin/docker /bin/docker
+COPY --from=vault /bin/vault /bin/vault
+COPY --from=terraform /bin/terraform /bin/terraform
+COPY --from=packer /bin/packer /bin/packer
+COPY --from=prometheus /bin/promtool /bin/promtool
+COPY --from=alertmanager /bin/amtool /bin/amtool
+COPY --from=yq /usr/bin/yq /usr/bin/yq
+COPY --from=compose /usr/local/bin/docker-compose /bin/docker-compose
+COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=helm2 /usr/local/bin/helm /usr/local/bin/helm2
+COPY --from=helm /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=cc-test-reporter /bin/cc-test-reporter /bin/cc-test-reporter
+COPY --from=golangci-lint /usr/bin/golangci-lint /bin/
+
+COPY --from=packages / /

--- a/go-build-1.18/README.md
+++ b/go-build-1.18/README.md
@@ -1,0 +1,19 @@
+# qlik/go-build
+
+This image is built to support building Go-based projects in CircleCI. It comes
+populated with software generally useful for building and deploying. See the
+`Dockerfile` in this folder for details.
+
+## Third-Party Licenses
+
+See the git repository for the source code information: https://github.com/qlik-oss/dockerfiles/blob/master/LICENSE
+
+As with all Docker images, these also contain other software which may be under other licenses, along with any direct or indirect dependencies of the primary software being contained.
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
+
+The licenses of the contained software can be determined by inspecting the [Dockerfile](https://github.com/qlik-oss/dockerfiles/blob/master/go-build/Dockerfile)
+
+## Unsupported
+
+The source code (Dockerfiles) and binaries (container images) that result are provided for convenience, and not supported in any way.

--- a/go-build-1.18/README.md
+++ b/go-build-1.18/README.md
@@ -1,8 +1,10 @@
-# qlik/go-build
+# qlik/go-build-1.18
 
 This image is built to support building Go-based projects in CircleCI. It comes
 populated with software generally useful for building and deploying. See the
 `Dockerfile` in this folder for details.
+
+**This image is a backward compatibility image avaiable for Go 1.18 only.**
 
 ## Third-Party Licenses
 
@@ -12,7 +14,7 @@ As with all Docker images, these also contain other software which may be under 
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
 
-The licenses of the contained software can be determined by inspecting the [Dockerfile](https://github.com/qlik-oss/dockerfiles/blob/master/go-build/Dockerfile)
+The licenses of the contained software can be determined by inspecting the [Dockerfile](https://github.com/qlik-oss/dockerfiles/blob/master/go-build-1.18/Dockerfile)
 
 ## Unsupported
 

--- a/go-build-1.18/awscli-requirements.txt
+++ b/go-build-1.18/awscli-requirements.txt
@@ -1,0 +1,12 @@
+awscli==1.22.47
+botocore==1.23.47
+colorama==0.4.3
+docutils==0.15.2
+jmespath==0.10.0
+pyasn1==0.4.8
+python-dateutil==2.8.2
+PyYAML==5.4.1
+rsa==4.7.2
+s3transfer==0.5.1
+six==1.16.0
+urllib3==1.26.8

--- a/go-build-1.18/readme.yaml
+++ b/go-build-1.18/readme.yaml
@@ -1,4 +1,4 @@
-name: go-build
+name: go-build-1.18
 description: |
     This image is built to support building Go-based projects in CircleCI. It comes
     populated with software generally useful for building and deploying. See the

--- a/go-build-1.18/readme.yaml
+++ b/go-build-1.18/readme.yaml
@@ -1,0 +1,5 @@
+name: go-build
+description: |
+    This image is built to support building Go-based projects in CircleCI. It comes
+    populated with software generally useful for building and deploying. See the
+    `Dockerfile` in this folder for details.

--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache \
     libgcc \
     build-base
 
-ENV GLIBC=2.31-r0
+ENV GLIBC=2.35-r1
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 

--- a/go-build/Dockerfile
+++ b/go-build/Dockerfile
@@ -12,12 +12,12 @@ FROM lachlanevenson/k8s-helm:v3.10.2 AS helm2
 FROM lachlanevenson/k8s-helm:v3.8.0 AS helm
 FROM golangci/golangci-lint:v1.44.0-alpine AS golangci-lint
 
-FROM alpine:3.15 AS cc-test-reporter
+FROM alpine:3.18 AS cc-test-reporter
 
 RUN wget -q -O /bin/cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
 RUN chmod +x /bin/cc-test-reporter
 
-FROM alpine:3.15 AS packages
+FROM alpine:3.18 AS packages
 
 RUN apk add --no-cache \
     zip \
@@ -52,7 +52,7 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/g
   && ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib \
   && ln -s /usr/lib/libgcc_s.so.1 /usr/glibc-compat/lib
 
-FROM golang:1.18.1-alpine AS build
+FROM golang:1.19.9-alpine AS build
 
 COPY --from=gomplate /gomplate /bin/gomplate
 COPY --from=docker /usr/local/bin/docker /bin/docker


### PR DESCRIPTION
## Changes
- golang image bumped to 1.19
- alpine image bumped to 3.18
- glibc bumped to 2.35-r1

In order to provide temporary compatibility, an image for go 1.18 is getting created as a fork of go-build

Signed-off-by: Masaru Hoshi <masaru.hoshi@qlik.com>
