### PR TITLE
Upgrade gomplate version to 4.3 on tiny-build image

### DIFF
--- a/tiny-build/Dockerfile
+++ b/tiny-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM hairyhenderson/gomplate:v3.11.7-slim AS gomplate
+FROM hairyhenderson/gomplate:v4.3 AS gomplate
 FROM docker:29.0.4 AS docker
 FROM docker/compose:1.29.2 AS compose
 FROM vault:1.13.3 AS vault


### PR DESCRIPTION
while testing the deployment of prometheus-operator for fed-stage locally, we noticed that a helm install could not be done due to the huge size of sli-rules under HEO common/metrics/common/sli-rules.yaml. As a result, we have split the SLI rules into groups through a gomplating function - https://github.com/qlik-trial/helm-environment-overrides/blob/ed2c210c222eaf66b8632100c6f80fd19e6e384b/common/metrics/common/prom-rules.yml#L5-L6

However, this is currently not supported in the current version of gomplate. Hence the PR aims to upgrade gomplate to the latest version. 

Changes tested locally through a temporary pipeline - https://ci.pipeline.k8s.qlikcloud.io/teams/main/pipelines/ist-fedramp-metrics-test/jobs/fed-stage-metrics-ha/builds/3#L693dab7a:6 fails since jq is not supported.

With latest version:
` % make tmp/prom-rules.yml
     % 
    % gomplate -v
     gomplate version 4.3.3
`


